### PR TITLE
Zuul: don't specify 'project.name'

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,6 +1,5 @@
 ---
 - project:
-    name: packit-service/upsint
     check:
       jobs:
         - pre-commit


### PR DESCRIPTION
When Zuul configuration is stored in the repository, this is optional
and guessed from the repo name if not present.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>