### PR TITLE
account for projects who do not use master as a default branch

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -19,9 +19,11 @@ from pathlib import Path
 from upsint.utils import clone_repo_and_cd_inside, set_upstream_remote
 
 
-def call_upsint(parameters, envs=None, cwd=None):
+def call_upsint(parameters, envs=None, cwd=None, return_output=False):
     """ invoke packit in a subprocess """
     cmd = ["python3", "-m", "upsint.cli"] + parameters
+    if return_output:
+        return subprocess.check_output(cmd, env=envs, cwd=cwd).decode()
     return subprocess.check_call(cmd, env=envs, cwd=cwd)
 
 
@@ -55,3 +57,15 @@ def test_checkout_pr(tmpdir):
         == b"pr/1\n"
     )
     assert subprocess.check_output(["git", "rev-parse", "HEAD"]) == commit
+
+
+def test_list_branches(tmp_path):
+    os.chdir(tmp_path)
+    repo_name = "research"
+    namespace = "packit-service"
+    repo_clone_url = f"https://github.com/{namespace}/{repo_name}"
+    clone_repo_and_cd_inside(repo_name, repo_clone_url, namespace)
+
+    out = call_upsint(["list-branches"], return_output=True)
+    assert "╒═" in out
+    assert "│ main" in out

--- a/upsint/core.py
+++ b/upsint/core.py
@@ -51,7 +51,7 @@ class App:
     def get_current_branch(self):
         return get_current_branch_name()
 
-    def list_branches(self, merged_with: str = "master"):
+    def list_branches(self, remote: str, merged_with: Optional[str] = None):
         """
         provide a list of branches with additional metadata
 
@@ -61,6 +61,10 @@ class App:
             "remote_tracking": "origin",  # can be None
         }
         """
+        if not merged_with:
+            url = self.guess_remote_url(remote=remote)
+            git_project = self.get_git_project(url)
+            merged_with = git_project.default_branch
         return sorted(
             list_local_branches(merged_with), key=lambda x: x["date"], reverse=True
         )


### PR DESCRIPTION
there is more and more project which use main as their primary
development branch

since we know this thanks to ogr's git_project.default_branch we can use
that instead of hardcoding master

sadly writing a test case for create-pr is not trivial: PR for this
change was created using itself :)