### PR TITLE
Rewrite `prompt_for_pr_content`

### DIFF
--- a/upsint/utils.py
+++ b/upsint/utils.py
@@ -130,13 +130,7 @@ def prompt_for_pr_content(template: str):
     Create a temporary file and feed it to $EDITOR so the user defines content
     for the PR, mainly title and body.
     """
-    if "EDITOR" in os.environ:
-        pr_content = click.edit(text=template, editor=os.getenv("EDITOR"))
-    else:
-        logger.warning(
-            "EDITOR environment variable is not set. Relying on click's automatic detection"
-        )
-        pr_content = click.edit(text=template)
+    pr_content = click.edit(text=template)
     if pr_content is None:
         raise RuntimeError("PR description was not saved")
 


### PR DESCRIPTION
Fixes #63 

#### Changes:
* Use `click.edit` for editing PR content
* Add `RuntimeError` for empty PR content

#### TODOs:
* [X] Replace `utils.prompt_for_pr_content` with `click.edit`
* [ ] Test case for creating PRs

#### Note for reviewer:
Please verify if relying on `click.edit`'s automatic editor detection instead of hardcoding `/bin/vi` is okay.

#### Tested locally:
1. With EDITOR env var set to /usr/bin/nano
    a. Close without saving ✅
    b. Save and then close ✅
    c. Not changing the contents ✅
2. With EDITOR env var set to /usr/bin/vi
    a. Close without saving ✅
    b. Save and then close ✅
    c. Not changing the contents ✅
3. Without EDITOR env var set
    a. Verify that vi opens ✅